### PR TITLE
Bump version

### DIFF
--- a/omaha/VERSION
+++ b/omaha/VERSION
@@ -4,5 +4,5 @@
 # REMEMBER TO INCREMENT BUILD BY TWO! BUILD SHOULD ALWAYS BE ODD!
 version_major = 1    # 1-65535
 version_minor = 3    # 0-65535
-version_build = 101   # 1-65535
+version_build = 111   # 1-65535
 version_patch = 0    # 0-65535

--- a/omaha/hammer.bat
+++ b/omaha/hammer.bat
@@ -1,4 +1,4 @@
-@echo off
+:: @echo off
 
 :: Hammer does not need this variable but the unit
 :: tests do.
@@ -46,19 +46,19 @@ goto set_env_variables
 :: Change these variables to match the local build environment.
 
 :: Directory where the Go programming language toolchain is installed.
-set GOROOT=C:\go
+set GOROOT=c:\My\Projects\CTheSigns\OmahaBuildTools\go\
 
 :: This directory is needed to find protoc.exe, which is the protocol buffer
 :: compiler. From the release page https://github.com/google/protobuf/releases,
 :: download the zip file protoc-$VERSION-win32.zip. It contains the protoc
 :: binary. Unzip the contents under C:\protobuf.
-set OMAHA_PROTOBUF_BIN_DIR=C:\protobuf\bin
+set OMAHA_PROTOBUF_BIN_DIR=c:\My\Projects\CTheSigns\OmahaBuildTools\protobuf\bin
 
 :: This directory is needed to find the protocol buffer source files. From the
 :: release page https://github.com/google/protobuf/releases, download the zip
 :: file protobuf-cpp-$VERSION.zip. Unzip the "src" sub-directory contents to
 :: C:\protobuf\src.
-set OMAHA_PROTOBUF_SRC_DIR=C:\protobuf\src
+set OMAHA_PROTOBUF_SRC_DIR=c:\My\Projects\CTheSigns\OmahaBuildTools\protobuf_src\src
 
 :: Directory where Python (python.exe) is installed.
 set OMAHA_PYTHON_DIR=C:\Python27
@@ -67,7 +67,7 @@ set OMAHA_PYTHON_DIR=C:\Python27
 set OMAHA_WIX_DIR=%WIX%\bin
 
 :: Root directory of the WTL installation.
-set OMAHA_WTL_DIR=C:\wtl\files
+set OMAHA_WTL_DIR=c:\My\Projects\CTheSigns\OmahaBuildTools\wtl\
 
 set OMAHA_PLATFORM_SDK_DIR=%WindowsSdkDir%\
 set OMAHA_WINDOWS_SDK_10_0_VERSION=%WindowsSDKVersion:~0,-1%
@@ -77,10 +77,10 @@ set OMAHA_SIGNTOOL_SDK_DIR="%WindowsSdkVerBinPath%\x86"
 set PYTHONPATH=%OMAHA_PYTHON_DIR%
 
 :: Directory of Scons (http://www.scons.org/).
-set SCONS_DIR=C:\Python27\Lib\site-packages\scons-1.3.1
+set SCONS_DIR=c:\Python27\scons-1.3.1\
 
 :: Directory of the Google's Software Construction Toolkit.
-set SCT_DIR=C:\swtoolkit
+set SCT_DIR=c:\My\Projects\CTheSigns\OmahaBuildTools\swtoolkit\
 
 set PROXY_CLSID_TARGET=%~dp0proxy_clsids.txt
 set CUSTOMIZATION_UT_TARGET=%~dp0common\omaha_customization_proxy_clsid.h


### PR DESCRIPTION
It's good practice to bump version each time we make any change for omaha client installer - in this case singing.
It ensures any old version installed is overriden with new version.
I also commited changes build script settings - it contains paths to local directories but we can change that later